### PR TITLE
Added a set-dotnet-env script for Xonsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ For fish shell, instead use:
 
 `source ~/.asdf/plugins/dotnet/set-dotnet-env.fish`
 
+For xonsh shell, instead use:
+
+`source ~/.asdf/plugins/dotnet/set-dotnet-env.xsh`
+
 # Contributing
 
 Contributions of any kind welcome! See the [contributing guide](contributing.md).

--- a/set-dotnet-env.xsh
+++ b/set-dotnet-env.xsh
@@ -1,0 +1,16 @@
+#!/usr/bin/env xonsh
+
+def asdf_update_dotnet_home() -> None:
+    dotnet_path=$(asdf which dotnet).rstrip('\n')
+    if dotnet_path:
+        $DOTNET_ROOT=$(dirname $(realpath @(dotnet_path))).rstrip('\n')
+        dotnet_version=$(dotnet --version).rstrip('\n')
+        $MSBuildSDKsPath=$DOTNET_ROOT + "/sdk/" + dotnet_version + "/Sdks"
+
+@events.on_chdir
+def update_dotnet_home_on_chdir(olddir, newdir, **kw) -> None:
+    asdf_update_dotnet_home()
+
+@events.on_post_init
+def update_dotnet_home_on_post_init() -> None:
+    asdf_update_dotnet_home()


### PR DESCRIPTION
This pull requests adds support for environment variables in [xonsh](https://xon.sh). It It is based upon a similar script in asdf-java, but with the appropriate variable names and paths.