### PR TITLE
feat: disable telemetry when setting global environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,14 @@
 # Contents
 
 - [Dependencies](#dependencies)
-- [Telemetry](#telemetry)
 - [Install](#install)
 - [Contributing](#contributing)
 - [License](#license)
-- [Updating DOTNET_ROOT and MsBuildSDksPath](#updating-variables)
+- [Updating global environment variables](#updating-variables)
 
 # Dependencies
 
 - `bash`, `curl`, `grep`, `sed`, `git`: generic POSIX utilities.
-
-# Telemetry
-
-> :warning: Once installed, the .NET SDK will collect telemetry by default ([learn more](https://learn.microsoft.com/en-us/dotnet/core/tools/telemetry#how-to-opt-out)). If you don't want to send analytics data to Microsoft, follow the instructions below before (or after) installing the SDK.
-
-To disable telemetry, add the following line to your shell profile (`~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, etc.):
-
-```shell
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-```
-
-Once added, reload your profile for the changes to take effect.
-
-```shell
-exec $SHELL
-```
 
 # Install
 
@@ -67,9 +50,15 @@ dotnet --version
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
 install & manage versions.
 
-# <a id="updating-variables"></a>Updating DOTNET_ROOT and MsBuildSDksPath
+# <a id="updating-variables"></a>Updating global environment variables
 
-According to your shell, add the following instructions to update or set the DOTNET_ROOT and MsBuildSDksPath environment variables:
+If you need to:
+
+- update/set `DOTNET_ROOT` variable
+- update/set `MsBuildSDksPath` variable
+- disable telemetry (i.e. set `DOTNET_CLI_TELEMETRY_OPTOUT` to 1)
+
+then, according to your shell, execute one of the following commands:
 
 For bash, use:
 

--- a/set-dotnet-env.bash
+++ b/set-dotnet-env.bash
@@ -7,6 +7,7 @@ asdf_update_dotnet_home() {
     export MSBuildSDKsPath
     DOTNET_VERSION="$(dotnet --version)"
     export MSBuildSDKsPath="$DOTNET_ROOT/sdk/$DOTNET_VERSION/Sdks"
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
   fi
 }
 

--- a/set-dotnet-env.fish
+++ b/set-dotnet-env.fish
@@ -5,5 +5,6 @@ function asdf_update_dotnet_home --on-event fish_prompt
         set -gx DOTNET_ROOT (dirname "$full_path")
         set --local dotnet_version (string replace -r '.*/installs/dotnet/(.+)/[.].*' '$1' $dotnet_path)
         set -gx MSBuildSDKsPath (realpath "$DOTNET_ROOT/sdk/$dotnet_version/Sdks")
+        set -gx DOTNET_CLI_TELEMETRY_OPTOUT 1
     end
 end

--- a/set-dotnet-env.zsh
+++ b/set-dotnet-env.zsh
@@ -7,6 +7,7 @@ asdf_update_dotnet_home() {
     export MSBuildSDKsPath
     DOTNET_VERSION="$(dotnet --version)"
     export MSBuildSDKsPath="$DOTNET_ROOT/sdk/$DOTNET_VERSION/Sdks"
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
   fi
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Docs have been added/updated.

### Description

Update `set-dotnet-env.*` scripts to disable telemetry.

Resolves #16 

[CONTRIBUTING.md]: https://github.com/hensou/asdf-dotnet/blob/main/contributing.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary