### PR TITLE
Include curl options when using curl in download function

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -35,7 +35,7 @@ FILE="releases.json"
 KEY="latest-sdk"
 
 download() {
-  curl -s $RELEASES_URI
+  curl "${curl_opts[@]}" $RELEASES_URI
 }
 
 match_key() {


### PR DESCRIPTION
Hi,

When using this plugin to install dotnet I ran into an issue where it didn't find any releases. I discovered that in order to access the GitHub url in the `RELEASES_URI` variable it requires the `-L` option for curl in order to follow redirects. 

I could simply have added the `-L` flag but when reading the script I noticed the `curl_opts` variable already existed so I decided to use that for the release list download.