### PR TITLE
feat: makes asdf-dotnet list all versions and improves performance

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,4 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions | sort_versions | xargs echo
+list_all_versions

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/dotnet/core"
 TOOL_NAME="dotnet"
 TOOL_TEST="dotnet --version"
 
@@ -13,49 +12,14 @@ fail() {
 
 curl_opts=(-fsSL)
 
-# NOTE: You might want to remove this if dotnet is not hosted on GitHub releases.
-if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-  curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
-fi
-
-sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
-list_github_tags() {
-  git ls-remote --tags --refs "$GH_REPO" |
-    grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
-}
-
-# taken from  asdf-dotnet-core plugin
-RELEASES_URI=https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases-index.json
-FILE="releases.json"
-KEY="latest-sdk"
+RELEASES_URI=https://raw.githubusercontent.com/hensou/asdf-dotnet/main/versions.txt
 
 download() {
   curl "${curl_opts[@]}" $RELEASES_URI
 }
 
-match_key() {
-  grep -Eo '"'$1'": \".*\"'
-}
-
-sanitize() {
-  sed -e 's/"'$1'": \"//;s/\"//'
-}
-
-gnutac() {
-  if hash tac 2>/dev/null; then
-    tac "$@"
-  else
-    tail -r "$@"
-  fi
-}
-
 list_all_versions() {
-  echo $(download | match_key $FILE | sanitize $FILE | xargs -n 1 -P 0 curl | match_key $KEY | sanitize $KEY | sort -r) | sed 's/ /\n/g'
+  download | tr '\n' ' '
 }
 
 download_installer() {
@@ -65,18 +29,6 @@ download_installer() {
   $downloader -sSL https://dot.net/v1/dotnet-install.sh >"$ASDF_DOWNLOAD_PATH/dotnet-install.sh"
   chmod +x "$ASDF_DOWNLOAD_PATH/dotnet-install.sh"
 
-}
-
-download_release() {
-  local version filename url
-  version="$1"
-  filename="$2"
-
-  # TODO: Adapt the release URL convention for dotnet
-  url="$GH_REPO/archive/v${version}.tar.gz"
-
-  echo "* Downloading $TOOL_NAME release $version..."
-  curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
 }
 
 install_version() {


### PR DESCRIPTION
This commit completly removes the depency on dotnet releases json maddness and instead uses a versions.txt file that gets updated on our own repo.

This makes it almost instantly to list all version as we only need to downloada simple txt file instead of waiting for hundreds of requests and processing json with bash.