### PR TITLE
fix: `set-dotnet-env.fish` failed to infer .NET version

### DIFF
--- a/set-dotnet-env.fish
+++ b/set-dotnet-env.fish
@@ -3,7 +3,7 @@ function asdf_update_dotnet_home --on-event fish_prompt
     if test -n "$dotnet_path"
         set --local full_path (realpath "$dotnet_path")
         set -gx DOTNET_ROOT (dirname "$full_path")
-        set --local dotnet_version (string replace -r '.*/installs/dotnet/(.+)/[.].*' '$1' $dotnet_path)
+        set --local dotnet_version (dotnet --version)
         set -gx MSBuildSDKsPath (realpath "$DOTNET_ROOT/sdk/$dotnet_version/Sdks")
         set -gx DOTNET_CLI_TELEMETRY_OPTOUT 1
     end


### PR DESCRIPTION
Changed to use `dotnet --version` like as others.